### PR TITLE
Improve error handling for database connection

### DIFF
--- a/app/api/replicache/pull/route.ts
+++ b/app/api/replicache/pull/route.ts
@@ -34,6 +34,12 @@ export async function POST(req: NextRequest) {
     if (e === authError) {
       return new NextResponse("Unauthorized", { status: 401 });
     }
+    if (e instanceof Error && e.message.includes("Tenant or user not found")) {
+      console.error(
+        "Invalid Supabase credentials. Check SUPABASE_DATABASE_URL."
+      );
+      return new NextResponse("Database connection error", { status: 500 });
+    }
     if ((e as NodeJS.ErrnoException).code === "ENOTFOUND") {
       console.error("Database host not found. Check SUPABASE_DATABASE_URL.");
       return new NextResponse("Database connection error", { status: 500 });

--- a/app/api/replicache/push/route.ts
+++ b/app/api/replicache/push/route.ts
@@ -44,6 +44,12 @@ export async function POST(req: NextRequest) {
   try {
     await processPush(push, userID);
   } catch (e) {
+    if (e instanceof Error && e.message.includes("Tenant or user not found")) {
+      console.error(
+        "Invalid Supabase credentials. Check SUPABASE_DATABASE_URL."
+      );
+      return new NextResponse("Database connection error", { status: 500 });
+    }
     if ((e as NodeJS.ErrnoException).code === "ENOTFOUND") {
       console.error("Database host not found. Check SUPABASE_DATABASE_URL.");
       return new NextResponse("Database connection error", { status: 500 });
@@ -52,7 +58,10 @@ export async function POST(req: NextRequest) {
       case authError:
         return new NextResponse("Unauthorized", { status: 401 });
       case clientStateNotFoundError:
-        return NextResponse.json({ error: "ClientStateNotFound" }, { status: 200 });
+        return NextResponse.json(
+          { error: "ClientStateNotFound" },
+          { status: 200 }
+        );
       default:
         console.error("Error processing push:", e);
         return new NextResponse("Internal Server Error", { status: 500 });


### PR DESCRIPTION
## Summary
- catch `Tenant or user not found` errors in push and pull routes

## Testing
- `npm run build` *(fails: Required env var 'SUPABASE_DATABASE_URL or DATABASE_URL' was not set)*

------
https://chatgpt.com/codex/tasks/task_e_687272281ab883329a4db590b2fcd943